### PR TITLE
bumped MarkupSafe from 1.0 to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ jmespath==0.9.3
 jsondiff==1.1.1
 jsonnet==0.10.0
 jsonpickle==1.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mock==2.0.0
 more-itertools==4.3.0
 moto==1.3.4


### PR DESCRIPTION
The installation was failing because of MarkUpSafe v1.0 as mentioned in the requirements.txt
Below error observed:

```
  Downloading MarkupSafe-1.0.tar.gz (14 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-7q8o1xwe/MarkupSafe/setup.py'"'"'; __file__='"'"'/tmp/pip-install-7q8o1xwe/MarkupSafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-7q8o1xwe/MarkupSafe/pip-egg-info
         cwd: /tmp/pip-install-7q8o1xwe/MarkupSafe/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-7q8o1xwe/MarkupSafe/setup.py", line 6, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```

The issue got resolved by changing to v 1.1.1
The `demo` is also working fine.